### PR TITLE
Add migratability hooks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+As titled.
+
+## Notes for reviewers
+
+None.
+
+## Changelog entries
+
+- **Added**:
+- **Changed**:
+- **Deprecated**:
+- **Removed**:
+- **Fixed**:
+- **Security**:
+
+## Issue(s)
+
+None.

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -3,7 +3,7 @@ name: Coding Standards
 on:
   push:
     branches:
-      - main
+      - develop
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,7 +3,7 @@ name: Testing Suite
 on:
   push:
     branches:
-      - main
+      - develop
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: main
+          ref: develop
 
       - name: Update Changelog
         uses: stefanzweifel/changelog-updater-action@v1
@@ -23,6 +23,6 @@ jobs:
       - name: Commit updated CHANGELOG
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          branch: main
+          branch: develop
           commit_message: Update CHANGELOG
           file_pattern: CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ This package follows semantic versioning conventions.
 
 This package is in a pre-release status. Milestones to be completed before the first release include:
 
-- Adding sidebar and menu support.
-- Adding theme mod support.
 - Adding feature testing.
 
 

--- a/src/class-controller.php
+++ b/src/class-controller.php
@@ -24,14 +24,14 @@ class Controller {
 	 *
 	 * @var WP_Theme_Migrator_WP
 	 */
-	protected $wp;
+	protected WP_Theme_Migrator_WP $wp;
 
 	/**
 	 * Whether to switch to the new theme for the current request.
 	 *
 	 * @var bool
 	 */
-	protected $should_migrate;
+	protected bool $should_migrate;
 
 	/**
 	 * Constructor.
@@ -203,5 +203,14 @@ class Controller {
 		if ( false !== $post_type_object->query_var && $this->wp && is_post_type_viewable( $post_type_object ) ) {
 			$this->wp->add_query_var( $post_type_object->query_var );
 		}
+	}
+
+	/**
+	 * Whether the current request is migratable.
+	 *
+	 * @return bool
+	 */
+	public function is_migratable(): bool {
+		return $this->should_migrate;
 	}
 }

--- a/src/class-controller.php
+++ b/src/class-controller.php
@@ -27,21 +27,17 @@ class Controller {
 	protected WP_Theme_Migrator_WP $wp;
 
 	/**
-	 * Whether to switch to the new theme for the current request.
-	 *
-	 * @var bool
-	 */
-	protected bool $should_migrate;
-
-	/**
 	 * Constructor.
 	 *
 	 * @param Context $context Context object.
+	 * @param bool    $should_migrate Whether to switch to the new theme for the
+	 * current request.
 	 *
 	 * @throws Exception Thrown if context is not valid.
 	 */
 	public function __construct(
 		protected Context $context,
+		protected bool $should_migrate = false,
 	) {
 		if ( ! $context->is_valid_context() ) {
 			throw new Exception(
@@ -107,6 +103,18 @@ class Controller {
 			}
 		}
 
+		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+			/**
+			 * Skip migration checks while doing Ajax.
+			 *
+			 * @param bool              $skip_during_ajax Whether to skip.
+			 * @param WP_Theme_Migrator $this This WP_Theme_Migrator instance.
+			 */
+			if ( apply_filters( 'wp_theme_migrator_skip_during_ajax', true, $this ) ) {
+				return;
+			}
+		}
+
 		$this->should_migrate = $this->check_migratability();
 	}
 
@@ -129,7 +137,6 @@ class Controller {
 	 */
 	protected function switch_theme() {
 		// @todo Add child theme support.
-		// @todo Add sidebar and menu support.
 
 		// Filtering the theme-related options early ensures the STYLESHEETPATH
 		// and TEMPLATEPATH constants are set.
@@ -176,9 +183,23 @@ class Controller {
 			// Because we're parsing the request early, the query vars will only
 			// include vars added in plugins, not themes.
 			if ( true === call_user_func_array( $callback, [ $this->wp->query_vars ] ) ) {
+
+				/**
+				 * Runs when a request is migratable.
+				 *
+				 * @param Controller $this Controller instance.
+				 */
+				do_action( 'wp_theme_migrator_migrating', $this );
 				return true;
 			}
 		}
+
+		/**
+		 * Runs when a request is not migratable.
+		 *
+		 * @param Controller $this Controller instance.
+		 */
+		do_action( 'wp_theme_migrator_not_migrating', $this );
 
 		return false;
 	}
@@ -187,7 +208,7 @@ class Controller {
 	 * Stop migrator.
 	 */
 	protected function stop_migrator() {
-		remove_action( 'setup_theme', [ $this, 'init' ], 100 );
+		remove_action( 'setup_theme', [ $this, 'run' ], 100 );
 		remove_action( 'registered_post_type', [ $this, 'add_post_type_query_vars' ], 10, 2 );
 	}
 
@@ -203,14 +224,5 @@ class Controller {
 		if ( false !== $post_type_object->query_var && $this->wp && is_post_type_viewable( $post_type_object ) ) {
 			$this->wp->add_query_var( $post_type_object->query_var );
 		}
-	}
-
-	/**
-	 * Whether the current request is migratable.
-	 *
-	 * @return bool
-	 */
-	public function is_migratable(): bool {
-		return $this->should_migrate;
 	}
 }


### PR DESCRIPTION
Adds the following actions:
* `wp_theme_migrator_skip_during_ajax` - Skip migration checks while doing Ajax.

Adds the following filter:
* `wp_theme_migrator_migrating` - Runs when a request is migratable.
* `wp_theme_migrator_not_migrating` - Runs when a request is not migratable.